### PR TITLE
Avoid setuptools management

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  script: python setup.py install
+  script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
   build:


### PR DESCRIPTION
As we manage packages through `conda` (not `setuptools`/`pip`), we need to side-step package management through other means. This is the [recommended way]( http://setuptools.readthedocs.io/en/latest/setuptools.html?highlight=single-version-externally-managed#what-your-users-should-know ) ( see "Creating System Packages" ) to do this.